### PR TITLE
Build arm64 Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,12 @@ jobs:
               run: |
                   echo "DOCKER_TAGS=${{ env.IMAGE_NAME }}:${{env.GITHUB_SHA_SHORT}},${{ env.IMAGE_NAME }}:${{ env.VERSION }}-git,${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.GITHUB_SHA_SHORT }},${{ env.IMAGE_NAME }}:${{ env.REFNAME }}-${{ env.GITHUB_SHA_SHORT }},${{ env.IMAGE_NAME }}:${{ env.REFNAME }}" >> "${GITHUB_ENV}"
 
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v2
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v2
+
             - name: "Login to github container registry"
               uses: 'docker/login-action@v1'
               with:
@@ -53,9 +59,11 @@ jobs:
                   username: ${{ secrets.CR_USER }}
                   password: ${{ secrets.CR_PAT }}
 
-            - name: "Build image builder"
-              uses: 'docker/build-push-action@v2'
+            - name: Build and push
+              uses: docker/build-push-action@v4
               with:
+                  context: .
+                  platforms: linux/amd64,linux/arm64
                   push: true
                   no-cache: true
                   build-args: |
@@ -65,4 +73,3 @@ jobs:
                       BUILD_DATE=${{ env.BUILD_DATE }}
                       VERSION=${{ env.VERSION_LABEL }}
                   tags: "${{ env.DOCKER_TAGS }}"
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: "Checkout"
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: "Set environment variables"
               run: |
@@ -53,7 +53,7 @@ jobs:
               uses: docker/setup-buildx-action@v2
 
             - name: "Login to github container registry"
-              uses: 'docker/login-action@v1'
+              uses: docker/login-action@v2.1
               with:
                   registry: ghcr.io
                   username: ${{ secrets.CR_USER }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
               uses: docker/setup-buildx-action@v2
 
             - name: "Login to github container registry"
-              uses: docker/login-action@v2.1
+              uses: docker/login-action@v2.1.0
               with:
                   registry: ghcr.io
                   username: ${{ secrets.CR_USER }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG SOURCE=local
-ARG IMAGE_BUILD=node:16-alpine3.14
+ARG IMAGE_BUILD=node:16-alpine3.17
 
 #----------------------------------------
 
@@ -34,8 +34,8 @@ FROM builder-${SOURCE} as builder
 RUN \
     cd /app && \
     yarn && \
-    yarn create-example-cache && \
-    PUBLIC_URL=${PUBLIC_URL} yarn build
+    yarn create-example-cache --verbose && \
+    PUBLIC_URL=${PUBLIC_URL} yarn build --verbose
 
 #----------------------------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ ARG IMAGE_BUILD=node:16-alpine3.17
 
 FROM ${IMAGE_BUILD} as builder-base
 
-RUN \
-    apk update && \
+RUN apk update && \
     apk add git
 
 #----------------------------------------
@@ -16,8 +15,7 @@ FROM builder-base as builder-git
 ARG REPO=https://github.com/webgiss/niolesk
 ARG POINT=main
 
-RUN \
-    git clone "${REPO}" /app && \
+RUN git clone "${REPO}" /app && \
     cd /app && \
     git checkout "${POINT}"
 
@@ -29,10 +27,11 @@ ARG PUBLIC_URL=/
 
 ADD . /app
 
+#----------------------------------------
+
 FROM builder-${SOURCE} as builder
 
-RUN \
-    cd /app && \
+RUN cd /app && \
     yarn && \
     yarn create-example-cache && \
     PUBLIC_URL=${PUBLIC_URL} yarn build
@@ -45,8 +44,7 @@ ARG VCS_REF=working-copy
 ARG BUILD_DATE=now
 ARG VERSION=dev
 
-LABEL \
-      org.opencontainers.image.created="${BUILD_DATE}" \
+LABEL org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.authors="gissehel" \
       org.opencontainers.image.url="https://github.com/webgiss/niolesk" \
       org.opencontainers.image.source="https://github.com/webgiss/niolesk" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ FROM builder-${SOURCE} as builder
 RUN \
     cd /app && \
     yarn && \
-    yarn create-example-cache --verbose && \
-    PUBLIC_URL=${PUBLIC_URL} yarn build --verbose
+    yarn create-example-cache && \
+    PUBLIC_URL=${PUBLIC_URL} yarn build
 
 #----------------------------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,14 @@ ARG IMAGE_BUILD=node:16-alpine3.17
 
 #----------------------------------------
 
-FROM ${IMAGE_BUILD} as builder-base
+FROM --platform=$BUILDPLATFORM ${IMAGE_BUILD} AS builder-base
 
 RUN apk update && \
     apk add git
 
 #----------------------------------------
 
-FROM builder-base as builder-git
+FROM builder-base AS builder-git
 
 ARG REPO=https://github.com/webgiss/niolesk
 ARG POINT=main
@@ -21,7 +21,7 @@ RUN git clone "${REPO}" /app && \
 
 #----------------------------------------
 
-FROM builder-base as builder-local
+FROM builder-base AS builder-local
 
 ARG PUBLIC_URL=/
 
@@ -29,10 +29,14 @@ ADD . /app
 
 #----------------------------------------
 
-FROM builder-${SOURCE} as builder
+FROM builder-${SOURCE} AS builder
 
-RUN cd /app && \
-    yarn && \
+ARG TARGETARCH
+ARG TARGETOS
+ENV npm_config_target_arch=$TARGETARCH
+ENV npm_config_target_platform=$TARGETOS
+WORKDIR /app
+RUN yarn && \
     yarn create-example-cache && \
     PUBLIC_URL=${PUBLIC_URL} yarn build
 


### PR DESCRIPTION
Updates the `build.yml` workflow to build a multi-arch Docker image with both `arm64` and `amd64` variants. This enables support for increasingly popular ARM-based machines and corresponds with a PR that is currently open in the main Kroki project (https://github.com/yuzutech/kroki/pull/1487). These changes are based on the multi-arch example provided in the Docker [documentation](https://docs.docker.com/build/ci/github-actions/multi-platform/).

Both variants are working locally on my machines, but I haven't been able to verify that the CI pipeline will pass because it runs on a schedule.